### PR TITLE
feature: Allow disabling fingerprint wake-and-unlock

### DIFF
--- a/app/src/main/java/com/android/settings/dotextras/custom/sections/SystemSection.kt
+++ b/app/src/main/java/com/android/settings/dotextras/custom/sections/SystemSection.kt
@@ -28,6 +28,7 @@ import com.android.settings.dotextras.R
 import com.android.settings.dotextras.custom.sections.cards.ContextCards
 import com.android.settings.dotextras.custom.sections.cards.ContextCardsAdapter.Type.SECURE
 import com.android.settings.dotextras.custom.sections.cards.ContextCardsAdapter.Type.SYSTEM
+import com.android.settings.dotextras.custom.utils.ResourceHelper
 import com.android.settings.dotextras.system.OverlayController
 import kotlin.properties.Delegates
 
@@ -226,12 +227,26 @@ open class SystemSection : GenericSection() {
 
         mFingerprintManager =
             requireContext().getSystemService(Context.FINGERPRINT_SERVICE) as FingerprintManager?
-        if (mFingerprintManager != null) {
+
+        if (mFingerprintManager?.isHardwareDetected == true) {
+            if (!ResourceHelper.hasFodSupport(requireContext())) {
+                buildSwitch(
+                    securityCardList,
+                    iconID = R.drawable.fod_icon_default_aosp,
+                    title = getString(R.string.enabled),
+                    subtitle = getString(R.string.fp_wake_unlock),
+                    accentColor = R.color.deep_orange_800,
+                    feature = featureManager.System().FP_WAKE_UNLOCK,
+                    featureType = SYSTEM,
+                    summary = getString(R.string.fp_wake_unlock_summary),
+                    enabled = true
+                )
+            }
+
             mDevicePolicyManager =
                 requireContext().getSystemService(Context.DEVICE_POLICY_SERVICE) as DevicePolicyManager
             mEncryptionStatus = mDevicePolicyManager.storageEncryptionStatus
-            if (mFingerprintManager!!.isHardwareDetected
-                && mEncryptionStatus != DevicePolicyManager.ENCRYPTION_STATUS_ACTIVE
+            if (mEncryptionStatus != DevicePolicyManager.ENCRYPTION_STATUS_ACTIVE
                 && mEncryptionStatus != DevicePolicyManager.ENCRYPTION_STATUS_ACTIVE_PER_USER
             ) {
                 buildSwitch(

--- a/app/src/main/java/com/android/settings/dotextras/system/FeatureManager.kt
+++ b/app/src/main/java/com/android/settings/dotextras/system/FeatureManager.kt
@@ -309,6 +309,11 @@ class FeatureManager(private val contentResolver: ContentResolver) {
         val FOD_NIGHT_LIGHT = "fod_night_light"
 
         /**
+         * fingerprint wake-and-unlock
+         */
+        val FP_WAKE_UNLOCK = "fp_wake_unlock"
+
+        /**
          * Unlock keystore with fingerprint after reboot
          */
         val FP_UNLOCK_KEYSTORE = "fp_unlock_keystore"

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -85,6 +85,8 @@
     <string name="threewayss_summary">使用三指截屏</string>
     <string name="biometrics_unlock">重启时开启指纹解锁</string>
     <string name="biometrics_unlock_summary">重启后使用生物测定技术解锁</string>
+    <string name="fp_wake_unlock">指纹唤醒解锁</string>
+    <string name="fp_wake_unlock_summary">允许使用指纹唤醒并解锁设备</string>
     <string name="volume_left">音量面板样式</string>
     <string name="volume_left_summary">对左撇子友好</string>
     <string name="fod_nightlight">屏幕指纹 夜光</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -77,6 +77,8 @@
     <string name="threewayss_summary">Take a screenshot using three fingers</string>
     <string name="biometrics_unlock">FP on reboot</string>
     <string name="biometrics_unlock_summary">Use biometrics to unlock after a reboot</string>
+    <string name="fp_wake_unlock">FP wake unlock</string>
+    <string name="fp_wake_unlock_summary">Use biometrics to unlock after a reboot</string>
     <string name="volume_left">Volume Panel</string>
     <string name="volume_left_summary">Make it left-handed friendly</string>
     <string name="fod_nightlight">FOD Nightlight</string>


### PR DESCRIPTION
* When the fingerprint sensor is embedded in the power key, wake-and-unlock is total chaos. Add an option to disable it.
* The default behavior is unchanged.
* source: https://github.com/ArrowOS/android_frameworks_base/commit/9df42e8d12759091d6d164871b64854f2fd9244d